### PR TITLE
Update docker image to use mirror.gcr.io

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 ---
 images:
-  bash: docker.io/library/bash:latest
-  builder: docker.io/paketobuildpacks/builder:base
+  bash: mirror.gcr.io/library/bash:latest
+  builder: mirror.gcr.io/paketobuildpacks/builder:base
 
 annotations:
   tekton.dev/categories: Image Build


### PR DESCRIPTION
An attempt to check if we can use mirror.gcr.io in place of docker.io to make OpenShift CI happy